### PR TITLE
Add .latexmkrc to tell latexmk to use xetex

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,0 +1,4 @@
+$pdf_mode = 5;
+$dvi_mode = 0;
+$postscript_mode = 0;
+


### PR DESCRIPTION
Run
`$ latexmk`
to build once or
`$ latexmk -pvc`
for continuous preview mode